### PR TITLE
記事登録の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -11,5 +11,16 @@ module Api::V1
 
       render json: @article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      @article = current_user.articles.create!(article_params)
+      render json: @article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  protect_from_forgery with: :null_session
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,8 @@ module RadiationLink
 
     config.api_only = true
 
+    config.middleware.use ActionDispatch::Flash
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## 概要
- ログインユーザによる記事の登録を実装
- ログインユーザに紐づく記事として登録
- ログインユーザを取得する機能は未実装なので、ダミーとして作成