### PR TITLE
記事関連画面のルーティングを作成

### DIFF
--- a/radiation_client/package.json
+++ b/radiation_client/package.json
@@ -26,7 +26,11 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "react-hooks/exhaustive-deps": "off"
+    }
+
   },
   "browserslist": {
     "production": [

--- a/radiation_client/src/App.tsx
+++ b/radiation_client/src/App.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import { ChakraProvider } from '@chakra-ui/react';
-import thema from './thema/thema';
+import thema from './theme/theme';
+import { BrowserRouter } from 'react-router-dom';
+
+import { Router } from './router/Router';
 
 function App() {
   return (
     <ChakraProvider theme={thema}>
-      <div>hello world</div>
+      <BrowserRouter>
+        <Router />
+      </BrowserRouter>
     </ChakraProvider>
   );
 }

--- a/radiation_client/src/components/pages/ArticleDetailScreen.tsx
+++ b/radiation_client/src/components/pages/ArticleDetailScreen.tsx
@@ -1,0 +1,7 @@
+import { FC, memo } from 'react';
+
+type Props = {};
+
+export const ArticleDetailScreen: FC<Props> = memo((props) => {
+  return <h1>記事詳細画面</h1>;
+});

--- a/radiation_client/src/components/pages/ArticleEditScreen.tsx
+++ b/radiation_client/src/components/pages/ArticleEditScreen.tsx
@@ -1,0 +1,7 @@
+import { FC, memo } from 'react';
+
+type Props = {};
+
+export const ArticleEditScreen: FC<Props> = memo((props) => {
+  return <h1>記事編集画面</h1>;
+});

--- a/radiation_client/src/components/pages/ArticlePreviewScreen.tsx
+++ b/radiation_client/src/components/pages/ArticlePreviewScreen.tsx
@@ -1,0 +1,7 @@
+import { FC, memo } from 'react';
+
+type Props = {};
+
+export const ArticlePreviewScreen: FC<Props> = memo((props) => {
+  return <h1>記事一覧画面</h1>;
+});

--- a/radiation_client/src/components/pages/Page404.tsx
+++ b/radiation_client/src/components/pages/Page404.tsx
@@ -1,0 +1,5 @@
+import { FC, memo } from 'react';
+
+export const Page404: FC = memo(() => {
+  return <h1>404ページです</h1>;
+});

--- a/radiation_client/src/router/ArticleRoutes.tsx
+++ b/radiation_client/src/router/ArticleRoutes.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+import { ArticlePreviewScreen } from '../components/pages/ArticlePreviewScreen';
+import { ArticleDetailScreen } from '../components/pages/ArticleDetailScreen';
+import { ArticleEditScreen } from '../components/pages/ArticleEditScreen';
+import { Page404 } from '../components/pages/Page404';
+
+export const ArticleRoutes: Array<{ path: string; children: ReactNode }> = [
+  {
+    path: '',
+    children: <ArticlePreviewScreen />,
+  },
+  {
+    path: ':id',
+    children: <ArticleDetailScreen />,
+  },
+  {
+    path: 'edit',
+    children: <ArticleEditScreen />,
+  },
+  {
+    path: '*',
+    children: <Page404 />,
+  },
+];

--- a/radiation_client/src/router/Router.tsx
+++ b/radiation_client/src/router/Router.tsx
@@ -1,0 +1,18 @@
+import { memo } from 'react';
+import { Route, Routes } from 'react-router-dom';
+
+import { ArticleRoutes } from './ArticleRoutes';
+import { Page404 } from '../components/pages/Page404';
+
+export const Router = memo(() => {
+  return (
+    <Routes>
+      {ArticleRoutes.map((url) => (
+        <Route path="/articles">
+          <Route path={url.path} element={url.children} />
+        </Route>
+      ))}
+      <Route path="*" element={<Page404 />} />
+    </Routes>
+  );
+});

--- a/radiation_client/src/theme/theme.ts
+++ b/radiation_client/src/theme/theme.ts
@@ -1,6 +1,6 @@
 import { extendTheme } from "@chakra-ui/react";
 
-const thema = extendTheme({
+const theme = extendTheme({
   styles: {
     global: {
       body: {
@@ -11,4 +11,4 @@ const thema = extendTheme({
   },
 });
 
-export default thema;
+export default theme;


### PR DESCRIPTION
## 概要
- useCallback の第二引数がからでも警告が出ないように修正
- 記事一覧、詳細、編集画面、404画面のコンポーネントを作成
- ルーティングを実装して各コンポーネントの表示を確認