### PR TITLE
アプリ全体のヘッダーを作成

### DIFF
--- a/radiation_client/src/components/atoms/button/MenuIconButton.tsx
+++ b/radiation_client/src/components/atoms/button/MenuIconButton.tsx
@@ -1,0 +1,21 @@
+import { HamburgerIcon } from '@chakra-ui/icons';
+import { IconButton } from '@chakra-ui/react';
+import { FC, memo } from 'react';
+
+type Props = {
+  onOpen: () => void;
+};
+
+export const MenuIconButton: FC<Props> = memo((props) => {
+  const { onOpen } = props;
+  return (
+    <IconButton
+      aria-label="メニューボタン"
+      icon={<HamburgerIcon />}
+      variant="unstyled"
+      size="xs"
+      display={{ base: 'block', md: 'none' }}
+      onClick={onOpen}
+    />
+  );
+});

--- a/radiation_client/src/components/molecules/MenuDrawer.tsx
+++ b/radiation_client/src/components/molecules/MenuDrawer.tsx
@@ -1,0 +1,39 @@
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerOverlay,
+} from '@chakra-ui/react';
+import { FC, memo } from 'react';
+import { useScreenTransition } from '../../hooks/useScreenTransition';
+
+type Props = {
+  onClose: () => void;
+  isOpen: boolean;
+};
+
+export const MenuDrawer: FC<Props> = memo((props) => {
+  const { onClose, isOpen } = props;
+  const { onClickArticles, onClickSetting, onClickUsers } =
+    useScreenTransition();
+  return (
+    <Drawer placement="left" size="xs" onClose={onClose} isOpen={isOpen}>
+      <DrawerOverlay>
+        <DrawerContent>
+          <DrawerBody bg="gray.100" p={0}>
+            <Button w="100%" onClick={onClickArticles}>
+              TOP
+            </Button>
+            <Button w="100%" onClick={onClickUsers}>
+              ユーザ一覧
+            </Button>
+            <Button w="100%" onClick={onClickSetting}>
+              設定
+            </Button>
+          </DrawerBody>
+        </DrawerContent>
+      </DrawerOverlay>
+    </Drawer>
+  );
+});

--- a/radiation_client/src/components/organisms/Header.tsx
+++ b/radiation_client/src/components/organisms/Header.tsx
@@ -1,0 +1,48 @@
+import { Box, Flex, Heading, Link, useDisclosure } from '@chakra-ui/react';
+import { FC, memo } from 'react';
+
+import { useScreenTransition } from '../../hooks/useScreenTransition';
+import { MenuIconButton } from '../atoms/button/MenuIconButton';
+import { MenuDrawer } from '../molecules/MenuDrawer';
+
+export const Header: FC = memo(() => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { onClickArticles, onClickSetting, onClickUsers } =
+    useScreenTransition();
+  return (
+    <>
+      <Flex
+        as="nav"
+        bg="teal.500"
+        color="gray.50"
+        align="center"
+        justify="space-between"
+        padding={{ base: 3, md: 5 }}
+      >
+        <Flex
+          as="a"
+          _hover={{ cursor: 'pointer' }}
+          mr={8}
+          onClick={onClickArticles}
+        >
+          <Heading as="h1" fontSize={{ base: 'md', md: 'lg' }}>
+            ユーザ管理アプリ
+          </Heading>
+        </Flex>
+        <Flex
+          align="center"
+          flexGrow={2}
+          display={{ base: 'none', md: 'flex' }}
+          fontSize="sm"
+        >
+          <Box pr={4}>
+            <Link onClick={onClickUsers}>ユーザ一覧</Link>
+          </Box>
+          <Link onClick={onClickSetting}>設定</Link>
+        </Flex>
+        <MenuIconButton onOpen={onOpen} />
+      </Flex>
+      <MenuDrawer onClose={onClose} isOpen={isOpen} />
+    </>
+  );
+});

--- a/radiation_client/src/components/templates/HeaderLayout.tsx
+++ b/radiation_client/src/components/templates/HeaderLayout.tsx
@@ -1,0 +1,17 @@
+import { FC, ReactNode, memo } from 'react';
+
+import { Header } from '../organisms/Header';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const HeaderLayout: FC<Props> = memo((props) => {
+  const { children } = props;
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+});

--- a/radiation_client/src/hooks/useScreenTransition.tsx
+++ b/radiation_client/src/hooks/useScreenTransition.tsx
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export const useScreenTransition = () => {
+  const navigate = useNavigate();
+
+  const onClickArticles = useCallback(() => navigate('/articles'), []);
+  const onClickUsers = useCallback(() => navigate('/users'), []);
+  const onClickSetting = useCallback(() => navigate('/setting'), []);
+
+  return { onClickArticles, onClickUsers, onClickSetting };
+};

--- a/radiation_client/src/router/Router.tsx
+++ b/radiation_client/src/router/Router.tsx
@@ -3,16 +3,27 @@ import { Route, Routes } from 'react-router-dom';
 
 import { ArticleRoutes } from './ArticleRoutes';
 import { Page404 } from '../components/pages/Page404';
+import { HeaderLayout } from '../components/templates/HeaderLayout';
 
 export const Router = memo(() => {
   return (
     <Routes>
       {ArticleRoutes.map((url) => (
         <Route path="/articles">
-          <Route path={url.path} element={url.children} />
+          <Route
+            path={url.path}
+            element={<HeaderLayout>{url.children}</HeaderLayout>}
+          />
         </Route>
       ))}
-      <Route path="*" element={<Page404 />} />
+      <Route
+        path="*"
+        element={
+          <HeaderLayout>
+            <Page404 />
+          </HeaderLayout>
+        }
+      />
     </Routes>
   );
 });


### PR DESCRIPTION
## 概要
- アプリ全体に表示するヘッダーを作成
- スマホ画面サイズをデフォルトとし、レスポンシブなデザインとする
- アプリ名とリンクをヘッダーに追加
- スマホ画面では、drawerによるリンクの表示とする
<img width="625" alt="スクリーンショット 2024-01-24 21 16 32" src="https://github.com/tadume/radiation_link/assets/111819973/f591a032-0f60-4d17-8c26-94cd5d8d9d10">
<img width="495" alt="スクリーンショット 2024-01-24 21 17 05" src="https://github.com/tadume/radiation_link/assets/111819973/bd76595f-957d-44fb-9417-31a5f8d28de9">
<img width="525" alt="スクリーンショット 2024-01-24 21 18 11" src="https://github.com/tadume/radiation_link/assets/111819973/ac8b91d1-e661-49bb-b442-837b34b96f84">


