### PR TITLE
記事投稿機能の実装

### DIFF
--- a/radiation_client/package.json
+++ b/radiation_client/package.json
@@ -10,6 +10,8 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "dompurify": "^3.0.8",
+    "easymde": "^2.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
@@ -26,7 +28,10 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "react-hooks/exhaustive-deps": "off"
+    }
   },
   "browserslist": {
     "production": [

--- a/radiation_client/src/components/atoms/button/PrimaryButton.tsx
+++ b/radiation_client/src/components/atoms/button/PrimaryButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@chakra-ui/react";
+import { FC, memo } from "react";
+
+type Props = {
+  children: string;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  onClick: () => void;
+};
+
+export const PrimaryButton: FC<Props> = memo((props) => {
+  const { children, isDisabled = false, isLoading = false, onClick } = props;
+  return (
+    <Button
+      color="white"
+      isLoading={isLoading}
+      isDisabled={isDisabled}
+      bg="#55c500"
+      colorScheme="none"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+});

--- a/radiation_client/src/components/atoms/button/SecondaryButton.tsx
+++ b/radiation_client/src/components/atoms/button/SecondaryButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@chakra-ui/react";
+import { FC, memo } from "react";
+
+type Props = {
+  children: string;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  onClick: () => void;
+};
+
+export const SecondaryButton: FC<Props> = memo((props) => {
+  const { children, isDisabled = false, isLoading = false, onClick } = props;
+  return (
+    <Button
+      border="1px"
+      color="black"
+      isLoading={isLoading}
+      isDisabled={isDisabled}
+      bg="white"
+      colorScheme="none"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+});

--- a/radiation_client/src/components/atoms/icon/HartIcon.tsx
+++ b/radiation_client/src/components/atoms/icon/HartIcon.tsx
@@ -1,5 +1,5 @@
-import { Icon, Text } from '@chakra-ui/react';
-import { FC, memo } from 'react';
+import { Icon } from "@chakra-ui/react";
+import { FC, memo } from "react";
 
 type Props = {
   iconSize: number;

--- a/radiation_client/src/components/molecules/MenuDrawer.tsx
+++ b/radiation_client/src/components/molecules/MenuDrawer.tsx
@@ -4,9 +4,9 @@ import {
   DrawerBody,
   DrawerContent,
   DrawerOverlay,
-} from '@chakra-ui/react';
-import { FC, memo } from 'react';
-import { useScreenTransition } from '../../hooks/useScreenTransition';
+} from "@chakra-ui/react";
+import { FC, memo } from "react";
+import { useScreenTransition } from "../../hooks/useScreenTransition";
 
 type Props = {
   onClose: () => void;
@@ -15,7 +15,7 @@ type Props = {
 
 export const MenuDrawer: FC<Props> = memo((props) => {
   const { onClose, isOpen } = props;
-  const { onClickArticles, onClickSetting, onClickUsers } =
+  const { onClickArticles, onClickSetting, onClickUsers, onClickNew } =
     useScreenTransition();
   return (
     <Drawer placement="left" size="xs" onClose={onClose} isOpen={isOpen}>
@@ -30,6 +30,9 @@ export const MenuDrawer: FC<Props> = memo((props) => {
             </Button>
             <Button w="100%" onClick={onClickSetting}>
               設定
+            </Button>
+            <Button w="100%" onClick={onClickNew}>
+              投稿する
             </Button>
           </DrawerBody>
         </DrawerContent>

--- a/radiation_client/src/components/organisms/EditHeader.tsx
+++ b/radiation_client/src/components/organisms/EditHeader.tsx
@@ -1,0 +1,47 @@
+import { Box, Flex, Heading } from "@chakra-ui/react";
+import { FC, memo } from "react";
+
+import { useScreenTransition } from "../../hooks/useScreenTransition";
+import { PrimaryButton } from "../atoms/button/PrimaryButton";
+import { SecondaryButton } from "../atoms/button/SecondaryButton";
+import { useNewArticle } from "../../hooks/api/articles/useNewArticle";
+
+export const EditHeader: FC = memo(() => {
+  const { onClickNew, onClickArticles } = useScreenTransition();
+  const { onCreateArticle } = useNewArticle();
+  return (
+    <>
+      <Flex
+        as="nav"
+        bg="white"
+        color="gray.50"
+        align="center"
+        justify="space-between"
+        padding={{ base: 3, md: 5 }}
+        mb="32px"
+      >
+        <Flex as="a" _hover={{ cursor: "pointer" }} mr={8}>
+          <Heading
+            as="h1"
+            fontSize={{ base: "md", md: "lg" }}
+            color="black"
+            onClick={onClickArticles}
+          >
+            Radiation Link
+          </Heading>
+        </Flex>
+        <Flex align="center" display={{ base: "none", md: "flex" }}>
+          <Box mr={4}>
+            <SecondaryButton onClick={onClickNew}>下書き保存</SecondaryButton>
+          </Box>
+          <PrimaryButton onClick={onCreateArticle}>
+            記事を投稿する
+          </PrimaryButton>
+        </Flex>
+        <Box display={{ base: "block", md: "none" }}>
+          <PrimaryButton onClick={onClickNew}>記事を投稿する</PrimaryButton>
+        </Box>
+      </Flex>
+    </>
+  );
+});

--- a/radiation_client/src/components/organisms/Header.tsx
+++ b/radiation_client/src/components/organisms/Header.tsx
@@ -1,14 +1,15 @@
-import { Box, Flex, Heading, Link, useDisclosure } from '@chakra-ui/react';
-import { FC, memo } from 'react';
+import { Flex, Heading, Icon, useDisclosure } from "@chakra-ui/react";
+import { FC, memo } from "react";
 
-import { useScreenTransition } from '../../hooks/useScreenTransition';
-import { MenuIconButton } from '../atoms/button/MenuIconButton';
-import { MenuDrawer } from '../molecules/MenuDrawer';
+import { useScreenTransition } from "../../hooks/useScreenTransition";
+import { MenuIconButton } from "../atoms/button/MenuIconButton";
+import { MenuDrawer } from "../molecules/MenuDrawer";
+import { PrimaryButton } from "../atoms/button/PrimaryButton";
+import { AtSignIcon } from "@chakra-ui/icons";
 
 export const Header: FC = memo(() => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { onClickArticles, onClickSetting, onClickUsers } =
-    useScreenTransition();
+  const { onClickArticles, onClickNew } = useScreenTransition();
   return (
     <>
       <Flex
@@ -22,24 +23,17 @@ export const Header: FC = memo(() => {
       >
         <Flex
           as="a"
-          _hover={{ cursor: 'pointer' }}
+          _hover={{ cursor: "pointer" }}
           mr={8}
           onClick={onClickArticles}
         >
-          <Heading as="h1" fontSize={{ base: 'md', md: 'lg' }}>
+          <Heading as="h1" fontSize={{ base: "md", md: "lg" }}>
             Radiation Link
           </Heading>
         </Flex>
-        <Flex
-          align="center"
-          flexGrow={2}
-          display={{ base: 'none', md: 'flex' }}
-          fontSize="sm"
-        >
-          <Box pr={4}>
-            <Link onClick={onClickUsers}>ユーザ一覧</Link>
-          </Box>
-          <Link onClick={onClickSetting}>設定</Link>
+        <Flex align="center" display={{ base: "none", md: "flex" }}>
+          <Icon as={AtSignIcon} boxSize={7} mr={5} />
+          <PrimaryButton onClick={onClickNew}>投稿する</PrimaryButton>
         </Flex>
         <MenuIconButton onOpen={onOpen} />
       </Flex>

--- a/radiation_client/src/components/pages/MDEditor.tsx
+++ b/radiation_client/src/components/pages/MDEditor.tsx
@@ -1,0 +1,57 @@
+import { ChangeEvent, FC, memo, useCallback, useContext, useMemo } from "react";
+import SimpleMdeReact from "react-simplemde-editor";
+import "easymde/dist/easymde.min.css";
+import { Input, Stack } from "@chakra-ui/react";
+import { ArticleContext } from "../../providers/ArticleProvider";
+
+export const MDEditor: FC = memo(() => {
+  const { title, body, setTitle, setBody, tags, setTags } =
+    useContext(ArticleContext);
+
+  const onChangeTitle = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+  }, []);
+
+  const onChangeBody = useCallback((value: string) => {
+    setBody(value);
+  }, []);
+
+  const onChangeTags = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setTags([...tags, event.target.value]);
+  }, []);
+
+  const autofocusNoSpellcheckerOptions = useMemo(() => {
+    return {
+      autofocus: true,
+      spellChecker: false,
+    };
+  }, []);
+
+  return (
+    <Stack mx={4}>
+      <Input
+        placeholder="記事タイトル"
+        value={title}
+        onChange={onChangeTitle}
+        bg="white"
+        variant="unstyled"
+        h={14}
+        fontSize="25px"
+      />
+      <Input
+        placeholder="タグを入力してください。スペース区切りで5つまで入力できます。"
+        onChange={onChangeTags}
+        bg="white"
+        variant="unstyled"
+        h={9}
+        fontSize="18px"
+      />
+      <SimpleMdeReact
+        value={body}
+        placeholder="Markdown記法で書いてみよう"
+        options={autofocusNoSpellcheckerOptions}
+        onChange={onChangeBody}
+      />
+    </Stack>
+  );
+});

--- a/radiation_client/src/components/templates/HeaderLayout.tsx
+++ b/radiation_client/src/components/templates/HeaderLayout.tsx
@@ -1,16 +1,15 @@
-import { FC, ReactNode, memo } from 'react';
-
-import { Header } from '../organisms/Header';
+import { FC, ReactNode, memo } from "react";
 
 type Props = {
+  header: ReactNode;
   children: ReactNode;
 };
 
 export const HeaderLayout: FC<Props> = memo((props) => {
-  const { children } = props;
+  const { children, header } = props;
   return (
     <>
-      <Header />
+      {header}
       {children}
     </>
   );

--- a/radiation_client/src/hooks/api/articles/useNewArticle.ts
+++ b/radiation_client/src/hooks/api/articles/useNewArticle.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+import { useCallback, useContext } from "react";
+import { ArticleType } from "../../../types/api/ArticleType";
+import { useToastMessage } from "../../useToastMessage";
+import { ArticleContext } from "../../../providers/ArticleProvider";
+import { useNavigate } from "react-router-dom";
+
+export const useNewArticle = () => {
+  const navigate = useNavigate();
+
+  const { title, body, setTitle, setBody } = useContext(ArticleContext);
+  const { showMessage } = useToastMessage();
+
+  const onCreateArticle = useCallback(() => {
+    axios
+      .post<ArticleType>("http://localhost:3001/api/v1/articles", {
+        title: title,
+        body: body,
+      })
+      .then((res) => {
+        console.log(res); // レスポンスデータを利用するかは考え中
+        showMessage({ title: "記事が投稿されました！", status: "success" });
+        navigate("/articles");
+      })
+      .catch((error) => {
+        console.log(error);
+        showMessage({ title: "記事を登録できませんでした。", status: "error" });
+      })
+      .finally(() => {
+        setTitle("");
+        setBody("");
+      });
+  }, [title, body]);
+
+  return { onCreateArticle };
+};

--- a/radiation_client/src/hooks/api/articles/useShowArticle.ts
+++ b/radiation_client/src/hooks/api/articles/useShowArticle.ts
@@ -12,14 +12,12 @@ export const useShowArticle = (articleId: string | undefined) => {
       .get<ArticleType>(`http://localhost:3001/api/v1/articles/${articleId}`)
       .then((res) => {
         setArticle(res.data);
-        console.log(res.data);
       })
       .catch((error) => {
         showMessage({
           title: "記事が取得できませんでした。",
           status: "error",
         });
-        console.log(error);
       });
   }, [setArticle]);
 

--- a/radiation_client/src/hooks/useScreenTransition.tsx
+++ b/radiation_client/src/hooks/useScreenTransition.tsx
@@ -1,12 +1,13 @@
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 
 export const useScreenTransition = () => {
   const navigate = useNavigate();
 
-  const onClickArticles = useCallback(() => navigate('/articles'), []);
-  const onClickUsers = useCallback(() => navigate('/users'), []);
-  const onClickSetting = useCallback(() => navigate('/setting'), []);
+  const onClickArticles = useCallback(() => navigate("/articles"), []);
+  const onClickUsers = useCallback(() => navigate("/users"), []);
+  const onClickSetting = useCallback(() => navigate("/setting"), []);
+  const onClickNew = useCallback(() => navigate("/articles/new"), []);
 
-  return { onClickArticles, onClickUsers, onClickSetting };
+  return { onClickArticles, onClickUsers, onClickSetting, onClickNew };
 };

--- a/radiation_client/src/providers/ArticleProvider.tsx
+++ b/radiation_client/src/providers/ArticleProvider.tsx
@@ -1,0 +1,42 @@
+import React, {
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  memo,
+  useState,
+} from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+type ArticleContextType = {
+  title: string;
+  body: string;
+  tags: Array<string | null>;
+  setTitle: Dispatch<SetStateAction<string>>;
+  setBody: Dispatch<SetStateAction<string>>;
+  setTags: Dispatch<SetStateAction<Array<string | null>>>;
+};
+
+export const ArticleContext = createContext<ArticleContextType>(
+  {} as ArticleContextType
+);
+
+export const ArticleProvider: FC<Props> = memo((props) => {
+  const [title, setTitle] = useState<string>("");
+  const [body, setBody] = useState<string>("");
+  const [tags, setTags] = useState<Array<string | null>>([]);
+
+  const { children } = props;
+
+  return (
+    <ArticleContext.Provider
+      value={{ title, body, tags, setTitle, setBody, setTags }}
+    >
+      {children}
+    </ArticleContext.Provider>
+  );
+});

--- a/radiation_client/src/router/ArticleRoutes.tsx
+++ b/radiation_client/src/router/ArticleRoutes.tsx
@@ -1,25 +1,25 @@
-import { ReactNode } from 'react';
+import { ReactNode } from "react";
 
-import { ArticlePreviewScreen } from '../components/pages/ArticlePreviewScreen';
-import { ArticleDetailScreen } from '../components/pages/ArticleDetailScreen';
-import { ArticleEditScreen } from '../components/pages/ArticleEditScreen';
-import { Page404 } from '../components/pages/Page404';
+import { ArticlePreviewScreen } from "../components/pages/ArticlePreviewScreen";
+import { ArticleDetailScreen } from "../components/pages/ArticleDetailScreen";
+import { Page404 } from "../components/pages/Page404";
+import { MDEditor } from "../components/pages/MDEditor";
 
 export const ArticleRoutes: Array<{ path: string; children: ReactNode }> = [
   {
-    path: '',
+    path: "",
     children: <ArticlePreviewScreen />,
   },
   {
-    path: ':id',
+    path: ":id",
     children: <ArticleDetailScreen />,
   },
   {
-    path: 'edit',
-    children: <ArticleEditScreen />,
+    path: "new",
+    children: <MDEditor />,
   },
   {
-    path: '*',
+    path: "*",
     children: <Page404 />,
   },
 ];

--- a/radiation_client/src/router/Router.tsx
+++ b/radiation_client/src/router/Router.tsx
@@ -1,31 +1,45 @@
-import { memo } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { memo } from "react";
+import { Route, Routes } from "react-router-dom";
 
-import { ArticleRoutes } from './ArticleRoutes';
-import { Page404 } from '../components/pages/Page404';
-import { HeaderLayout } from '../components/templates/HeaderLayout';
+import { ArticleRoutes } from "./ArticleRoutes";
+import { Page404 } from "../components/pages/Page404";
+import { HeaderLayout } from "../components/templates/HeaderLayout";
+import { Header } from "../components/organisms/Header";
+import { EditHeader } from "../components/organisms/EditHeader";
+import { ArticleProvider } from "../providers/ArticleProvider";
 
 export const Router = memo(() => {
   return (
-    <Routes>
-      <Route path="/articles">
-        {ArticleRoutes.map((url) => (
-          <Route
-            key={url.path}
-            path={url.path}
-            element={<HeaderLayout>{url.children}</HeaderLayout>}
-          />
-        ))}
-      </Route>
-
-      <Route
-        path="*"
-        element={
-          <HeaderLayout>
-            <Page404 />
-          </HeaderLayout>
-        }
-      />
-    </Routes>
+    <ArticleProvider>
+      <Routes>
+        <Route path="/articles">
+          {ArticleRoutes.map((url) => (
+            <Route
+              key={url.path}
+              path={url.path}
+              element={
+                url.path === "new" ? (
+                  <HeaderLayout header={<EditHeader />}>
+                    {url.children}
+                  </HeaderLayout>
+                ) : (
+                  <HeaderLayout header={<Header />}>
+                    {url.children}
+                  </HeaderLayout>
+                )
+              }
+            />
+          ))}
+        </Route>
+        <Route
+          path="*"
+          element={
+            <HeaderLayout header={<Header />}>
+              <Page404 />
+            </HeaderLayout>
+          }
+        />
+      </Routes>
+    </ArticleProvider>
   );
 });

--- a/radiation_client/yarn.lock
+++ b/radiation_client/yarn.lock
@@ -1964,6 +1964,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/codemirror@^5.60.4":
+  version "5.60.15"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.15.tgz#0f82be6f4126d1e59cf4c4830e56dcd49d3c3e8a"
+  integrity sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==
+  dependencies:
+    "@types/tern" "*"
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
@@ -2093,6 +2100,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/marked@^4.0.7":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.3.2.tgz#e2e0ad02ebf5626bd215c5bae2aff6aff0ce9eac"
+  integrity sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==
 
 "@types/mime@*":
   version "3.0.4"
@@ -2226,6 +2238,13 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/tern@*":
+  version "0.23.9"
+  resolved "https://registry.yarnpkg.com/@types/tern/-/tern-0.23.9.tgz#6f6093a4a9af3e6bb8dde528e024924d196b367c"
+  integrity sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==
+  dependencies:
+    "@types/estree" "*"
 
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.9"
@@ -3267,6 +3286,18 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+codemirror-spell-checker@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
+  integrity sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==
+  dependencies:
+    typo-js "*"
+
+codemirror@^5.63.1:
+  version "5.65.16"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.16.tgz#efc0661be6bf4988a6a1c2fe6893294638cdb334"
+  integrity sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz#c0b29bcd33bcd0779a1344c2136051e6afd3d9e9"
@@ -3921,6 +3952,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.8.tgz#e0021ab1b09184bc8af7e35c7dd9063f43a8a437"
+  integrity sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==
+
 domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -3965,6 +4001,17 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+easymde@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.18.0.tgz#ff1397d07329b1a7b9187d2d0c20766fa16b3b1b"
+  integrity sha512-IxVVUxNWIoXLeqtBU4BLc+eS/ScYhT1Dcb6yF5Wchoj1iXAV+TIIDWx+NCaZhY7RcSHqDPKllbYq7nwGKILnoA==
+  dependencies:
+    "@types/codemirror" "^5.60.4"
+    "@types/marked" "^4.0.7"
+    codemirror "^5.63.1"
+    codemirror-spell-checker "1.1.2"
+    marked "^4.1.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6506,6 +6553,11 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+marked@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -9116,6 +9168,11 @@ typescript@^4.4.2:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typo-js@*:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/typo-js/-/typo-js-1.2.3.tgz#aa7fab3cfcc3bba01746df06fceb93b7f786c6ac"
+  integrity sha512-67Hyl94beZX8gmTap7IDPrG5hy2cHftgsCAcGvE1tzuxGT+kRB+zSBin0wIMwysYw8RUCBCvv9UfQl8TNM75dA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 概要
- 記事投稿ボタンを設置
- 記事投稿画面用のヘッダーを作成
- 記事投稿時にモーダルを表示
- マークダウンエディタを作成
## 制約
- マークダウンエディタには、プレビュー機能を未実装
- ログインユーザに関係なく、記事投稿が可能な状態になっている。

https://github.com/tadume/radiation_link/assets/111819973/81c259c7-1b2c-4d7d-8b25-a1efac0876d3

